### PR TITLE
parseJSON.c - redundant jnObjectAppendEntry

### DIFF
--- a/examples/JSON/parseJSON.c
+++ b/examples/JSON/parseJSON.c
@@ -121,7 +121,6 @@ static jnEntry entryCreate(jnObject object, utSym key, jnValue value) {
   jnEntry entry = jnEntryAlloc();
   jnEntrySetSym(entry, key);
   jnEntrySetValue(entry, value);
-  jnObjectAppendEntry(object, entry);
   return entry;
 }
 


### PR DESCRIPTION

Interesting bug - re-appending the same entry creates a nice infinite loop.
I wonder if there would be an easy way to detect this in debug mode.
Probably not because the entries are child_only.

Anyways, I tested some JSON with this one line fix and everything worked as expected.
Thanks again for creating this nice, easy to understand example.
